### PR TITLE
Add Mlflow configuration for alternative S3 object storage

### DIFF
--- a/charts/mlflow-server/templates/deployment.yaml
+++ b/charts/mlflow-server/templates/deployment.yaml
@@ -48,7 +48,6 @@ spec:
               path: /health
               port: http
           env:
-            {{ if .Values.objectStorage.objectBucketClaim.enabled }}
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
@@ -59,6 +58,12 @@ spec:
                 secretKeyRef:
                   name: {{ include "mlflow-server.fullname" . }}
                   key: AWS_SECRET_ACCESS_KEY
+            - name: MLFLOW_S3_BUCKET_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "mlflow-server.fullname" . }}
+                  key: BUCKET_NAME
+            {{ if .Values.objectStorage.objectBucketClaim.enabled }}
             - name: BUCKET_HOST
               valueFrom:
                 configMapKeyRef:
@@ -69,22 +74,14 @@ spec:
                 configMapKeyRef:
                   name: {{ include "mlflow-server.fullname" . }}
                   key: BUCKET_PORT
-            - name: MLFLOW_S3_BUCKET_NAME
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "mlflow-server.fullname" . }}
-                  key: BUCKET_NAME
             - name: MLFLOW_S3_ENDPOINT_URL
               value: 'https://$(BUCKET_HOST):$(BUCKET_PORT)'
             {{ else  }}
-            - name: AWS_ACCESS_KEY_ID
-              value: {{ .Values.objectStorage.s3AccessKeyId }}
-            - name: AWS_SECRET_ACCESS_KEY
-              value: {{ .Values.objectStorage.s3SecretAccessKey }}
-            - name: MLFLOW_S3_BUCKET_NAME
-              value: {{ .Values.objectStorage.mlflowBucketName }}
             - name: MLFLOW_S3_ENDPOINT_URL
-              value: {{ .Values.objectStorage.s3EndpointUrl }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "mlflow-server.fullname" . }}
+                  key: S3_ENDPOINT_URL
             {{ end }}
             - name: AWS_CA_BUNDLE
               value: /run/secrets/kubernetes.io/serviceaccount/service-ca.crt

--- a/charts/mlflow-server/templates/deployment.yaml
+++ b/charts/mlflow-server/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
               path: /health
               port: http
           env:
-            {{ if .Values.objectBucketClaim.enabled }}
+            {{ if .Values.objectStorage.objectBucketClaim.enabled }}
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
@@ -69,16 +69,25 @@ spec:
                 configMapKeyRef:
                   name: {{ include "mlflow-server.fullname" . }}
                   key: BUCKET_PORT
-            - name: MLFLOW_S3_ENDPOINT_URL
-              value: 'https://$(BUCKET_HOST):$(BUCKET_PORT)'
             - name: MLFLOW_S3_BUCKET_NAME
               valueFrom:
                 configMapKeyRef:
                   name: {{ include "mlflow-server.fullname" . }}
                   key: BUCKET_NAME
+            - name: MLFLOW_S3_ENDPOINT_URL
+              value: 'https://$(BUCKET_HOST):$(BUCKET_PORT)'
+            {{ else  }}
+            - name: AWS_ACCESS_KEY_ID
+              value: {{ .Values.objectStorage.S3AccessKeyId }}
+            - name: AWS_SECRET_ACCESS_KEY
+              value: {{ .Values.objectStorage.S3SecretAccessKey }}
+            - name: MLFLOW_S3_BUCKET_NAME
+              value: {{ .Values.objectStorage.MlflowBucketName }}
+            - name: MLFLOW_S3_ENDPOINT_URL
+              value: {{ .Values.objectStorage.S3EndpointUrl }}
+            {{ end }}
             - name: AWS_CA_BUNDLE
               value: /run/secrets/kubernetes.io/serviceaccount/service-ca.crt
-            {{ end }}
             {{ if .Values.crunchyPostgres.enabled }}
             - name: PGBOUNCE_HOST
               valueFrom:

--- a/charts/mlflow-server/templates/deployment.yaml
+++ b/charts/mlflow-server/templates/deployment.yaml
@@ -78,13 +78,13 @@ spec:
               value: 'https://$(BUCKET_HOST):$(BUCKET_PORT)'
             {{ else  }}
             - name: AWS_ACCESS_KEY_ID
-              value: {{ .Values.objectStorage.S3AccessKeyId }}
+              value: {{ .Values.objectStorage.s3AccessKeyId }}
             - name: AWS_SECRET_ACCESS_KEY
-              value: {{ .Values.objectStorage.S3SecretAccessKey }}
+              value: {{ .Values.objectStorage.s3SecretAccessKey }}
             - name: MLFLOW_S3_BUCKET_NAME
-              value: {{ .Values.objectStorage.MlflowBucketName }}
+              value: {{ .Values.objectStorage.mlflowBucketName }}
             - name: MLFLOW_S3_ENDPOINT_URL
-              value: {{ .Values.objectStorage.S3EndpointUrl }}
+              value: {{ .Values.objectStorage.s3EndpointUrl }}
             {{ end }}
             - name: AWS_CA_BUNDLE
               value: /run/secrets/kubernetes.io/serviceaccount/service-ca.crt

--- a/charts/mlflow-server/templates/objectbucketclaim.yaml
+++ b/charts/mlflow-server/templates/objectbucketclaim.yaml
@@ -13,5 +13,5 @@ spec:
   additionalConfig:
     bucketclass: noobaa-default-bucket-class
   generateBucketName: {{ include "mlflow-server.fullname" . }}
-  storageClassName: {{ .Values.objectBucketClaim.objectStorage.storageClassName }}
+  storageClassName: {{ .Values.objectStorage.objectBucketClaim.storageClassName }}
 {{- end }}

--- a/charts/mlflow-server/templates/objectbucketclaim.yaml
+++ b/charts/mlflow-server/templates/objectbucketclaim.yaml
@@ -1,11 +1,11 @@
-{{- if .Values.objectBucketClaim.enabled -}}
+{{- if .Values.objectStorage.objectBucketClaim.enabled -}}
 apiVersion: objectbucket.io/v1alpha1
 kind: ObjectBucketClaim
 metadata:
   name: {{ include "mlflow-server.fullname" . }}
   labels:
     {{- include "mlflow-server.labels" . | nindent 4 }}
-  {{- with .Values.objectBucketClaim.annotations }}
+  {{- with .Values.objectStorage.objectBucketClaim.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -13,5 +13,5 @@ spec:
   additionalConfig:
     bucketclass: noobaa-default-bucket-class
   generateBucketName: {{ include "mlflow-server.fullname" . }}
-  storageClassName: {{ .Values.objectBucketClaim.storageClassName }}
+  storageClassName: {{ .Values.objectBucketClaim.objectStorage.storageClassName }}
 {{- end }}

--- a/charts/mlflow-server/templates/s3ConfigMap.yaml
+++ b/charts/mlflow-server/templates/s3ConfigMap.yaml
@@ -1,0 +1,11 @@
+{{- if not .Values.objectStorage.objectBucketClaim.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mlflow-server.fullname" . }}
+  labels:
+    {{- include "mlflow-server.labels" . | nindent 4 }}
+data:
+  BUCKET_NAME: {{ .Values.objectStorage.mlflowBucketName }}
+  S3_ENDPOINT_URL: {{ .Values.objectStorage.s3EndpointUrl }}
+{{- end }}

--- a/charts/mlflow-server/templates/s3Secret.yaml
+++ b/charts/mlflow-server/templates/s3Secret.yaml
@@ -1,0 +1,11 @@
+{{- if not .Values.objectStorage.objectBucketClaim.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "mlflow-server.fullname" . }}
+  labels:
+    {{- include "mlflow-server.labels" . | nindent 4 }}
+data:
+  AWS_ACCESS_KEY_ID: {{ .Values.objectStorage.s3AccessKeyId | b64enc }}
+  AWS_SECRET_ACCESS_KEY: {{ .Values.objectStorage.s3SecretAccessKey | b64enc }}
+{{- end }}

--- a/charts/mlflow-server/templates/tests/test-training.yaml
+++ b/charts/mlflow-server/templates/tests/test-training.yaml
@@ -16,7 +16,7 @@ spec:
           value: 'http://{{ include "mlflow-server.fullname" . }}:{{ .Values.service.port }}'
         - name: MLFLOW_EXPERIMENT
           value: helm-test
-        # {{ if .Values.objectBucketClaim.enabled }}
+        # {{ if .Values.objectStorage.objectBucketClaim.enabled }}
         # - name: AWS_ACCESS_KEY_ID
         #   valueFrom:
         #     secretKeyRef:

--- a/charts/mlflow-server/values.yaml
+++ b/charts/mlflow-server/values.yaml
@@ -56,15 +56,22 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
-objectBucketClaim:
-  # -- Enable creation of s3 bucket with objectBucketClaim for artifact storage
-  enabled: true
-  # -- StorageClassName for creation of the objectBucketClaim
-  storageClassName: openshift-storage.noobaa.io
-  # -- BucketClass name for the creation of the objectBucketClaim
-  bucketclass: noobaa-default-bucket-class
-  # -- Additional custom annotations for the objectBucketClaim
-  annotations: {}
+objectStorage:
+  objectBucketClaim:
+    # -- Enable creation of s3 bucket with objectBucketClaim for artifact storage
+    enabled: true
+    # -- StorageClassName for creation of the objectBucketClaim
+    storageClassName: openshift-storage.noobaa.io
+    # -- BucketClass name for the creation of the objectBucketClaim
+    bucketclass: noobaa-default-bucket-class
+    # -- Additional custom annotations for the objectBucketClaim
+    annotations: {}
+  # -- Set endpoint URL, bucket name and credentials if objectBucketClaim is disabled
+  # -- If objectBucketClaim is enabled, these values are overriden
+  S3EndpointUrl: {}
+  MlflowBucketName: {}
+  S3AccessKeyId: {}
+  S3SecretAccessKey: {}
 
 crunchyPostgres:
   # -- Enable creation of a postgres instance using crunchyPostgres operator

--- a/charts/mlflow-server/values.yaml
+++ b/charts/mlflow-server/values.yaml
@@ -68,10 +68,10 @@ objectStorage:
     annotations: {}
   # -- Set endpoint URL, bucket name and credentials if objectBucketClaim is disabled
   # -- If objectBucketClaim is enabled, these values are overriden
-  S3EndpointUrl: {}
-  MlflowBucketName: {}
-  S3AccessKeyId: {}
-  S3SecretAccessKey: {}
+  s3EndpointUrl: {}
+  mlflowBucketName: {}
+  s3AccessKeyId: {}
+  s3SecretAccessKey: {}
 
 crunchyPostgres:
   # -- Enable creation of a postgres instance using crunchyPostgres operator

--- a/charts/mlflow-server/values.yaml
+++ b/charts/mlflow-server/values.yaml
@@ -66,12 +66,14 @@ objectStorage:
     bucketclass: noobaa-default-bucket-class
     # -- Additional custom annotations for the objectBucketClaim
     annotations: {}
-  # -- Set endpoint URL, bucket name and credentials if objectBucketClaim is disabled
-  # -- If objectBucketClaim is enabled, these values are overriden
-  s3EndpointUrl: {}
-  mlflowBucketName: {}
-  s3AccessKeyId: {}
-  s3SecretAccessKey: {}
+  # -- URL for s3 endpoint if the objectBucketClaim is disabled
+  s3EndpointUrl: ""
+  # -- Name of the s3 bucket if the objectBucketClaim is disabled
+  mlflowBucketName: "mlflow"
+  # -- S3 Access Key ID if the objectBucketClaim is disabled
+  s3AccessKeyId: ""
+  # -- S3 Secret Access Key if the objectBucketClaim is disabled
+  s3SecretAccessKey: ""
 
 crunchyPostgres:
   # -- Enable creation of a postgres instance using crunchyPostgres operator


### PR DESCRIPTION
The current Mlflow Helm chart depends on S3 bucket provisioning through object bucket claims (OpenShift Data Foundation).

I've extended the chart to enable manually setting S3 endpoint information and credentials for consuming existing S3 buckets, so alternative S3 storage solutions can be used.